### PR TITLE
feat: add signout component and a dashboard entry point

### DIFF
--- a/src/components/SignIn/SignOut.tsx
+++ b/src/components/SignIn/SignOut.tsx
@@ -1,0 +1,8 @@
+import { firebaseSignOut } from "@/lib/firebase";
+import { Button } from "@chakra-ui/react";
+
+const SignOut = () => {
+  return <Button onClick={firebaseSignOut}>Sign Out</Button>;
+};
+
+export default SignOut;

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+import { useContext, useEffect } from "react";
+import SignOut from "@/components/SignIn/SignOut";
+import { UserContext } from "@/lib/context";
+import { Container } from "@chakra-ui/react";
+
+const Dashboard = () => {
+  const userData = useContext(UserContext);
+  const router = useRouter();
+  useEffect(() => {
+    if (!userData.user) {
+      router.push("/");
+    }
+  }, [userData.user]);
+  return (
+    <Container>
+      <SignOut />
+    </Container>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,10 +1,21 @@
 import SignInForm from "@/components/SignIn/SignInForm";
 import SignInLayout from "@/components/SignIn/SignInLayout";
 import SignInWithGoogle from "@/components/SignIn/SignInWithGoogle";
+import { useUserData } from "@/lib/hooks";
 import { Center, Divider, Flex, Text } from "@chakra-ui/react";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 const SignIn = () => {
+  const { user } = useUserData();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.push("/dashboard");
+    }
+  }, [user]);
   return (
     <SignInLayout heading="Welcome" subheading="Sign in to your account">
       <Flex direction="column" gap={5}>


### PR DESCRIPTION
Once the user is signed in, they are redirected to /dashboard which will have the entry point to the app

If the user is signed out, and tries to access /dashboard route, they are redirected to homepage